### PR TITLE
Implement basic truck simulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ This repository contains a small Streamlit application and accompanying tests. F
 - **Testing**: Always run `pytest -q` and ensure it succeeds before committing.
 - **Python Version**: Use Python 3.10 or newer.
 - **Grid Size**: The grid should remain 50x50 unless future requirements say otherwise.
-- **UI Framework**: Streamlit is used for the UI. Tests may mock Streamlit where necessary.
 - **Modularity**: Keep code modular and add unit tests for new functionality.
-- **Running the App**: Use `streamlit run app.py` from the repository root to start the interface.
 - **Dependencies**: Install Python packages from `requirements.txt`.
 
 Document any user-facing changes in the README when appropriate.
+
+You do not have to use Python to build the front-end. You may use React or Node.js as long as you include complete instructions to run the app in the README.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Run unit tests with:
 pytest -q
 ```
 
+## Simulation
+The `miney.simulation` module contains a simple truck engine. Trucks follow a
+pre-computed looped route from the load cell to the dump cell and back again.
+Each truck waits for a configurable number of ticks at the load and dump
+locations before continuing its journey.
+
 ## Project Details
 This project involves developing a Python-based, interactive 2D mine simulation application. The app models haul trucks moving between a loading ground and dumping ground on a user-defined road network within a 50×50 grid. The simulation will be visualized in a Streamlit or Gradio interface and allow basic controls (start, reset, add trucks). Truck motion is governed by pathfinding logic. This tool is intended for demonstration purposes and educational use.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ If everything is working you should see a 50x50 grid rendered as a single
 image, not a matrix of buttons. A grey road runs across the middle row with a
 green cell at the far left (the load zone) and a red cell at the far right (the
 dump zone). The layout is loaded from `maps/simple_map.json` and can be replaced
-with other map files.
+with other map files. The interface also provides buttons to start or stop the
+simulation, reset all trucks, and spawn additional trucks. Truck positions are
+displayed on the grid as yellow squares.
 
 ## Testing
 Run unit tests with:
@@ -48,6 +50,9 @@ The `miney.simulation` module contains a simple truck engine. Trucks follow a
 pre-computed looped route from the load cell to the dump cell and back again.
 Each truck waits for a configurable number of ticks at the load and dump
 locations before continuing its journey.
+The Streamlit app visualizes the simulation in real time using yellow
+markers for trucks. Buttons allow you to start or stop the engine, add
+new trucks and reset the fleet.
 
 ## Project Details
 This project involves developing a Python-based, interactive 2D mine simulation application. The app models haul trucks moving between a loading ground and dumping ground on a user-defined road network within a 50×50 grid. The simulation will be visualized in a Streamlit or Gradio interface and allow basic controls (start, reset, add trucks). Truck motion is governed by pathfinding logic. This tool is intended for demonstration purposes and educational use.

--- a/app.py
+++ b/app.py
@@ -1,18 +1,41 @@
+import time
 import streamlit as st
 
-from miney.grid import Grid
 from miney.map_loader import load_grid
-from miney.ui import render_grid
+from miney.simulation import Simulation
+from miney.ui import render_simulation
 
 st.set_page_config(page_title="Miney Grid")
 
-if "grid" not in st.session_state:
-    st.session_state.grid = load_grid("maps/simple_map.json")
+if "simulation" not in st.session_state:
+    grid = load_grid("maps/simple_map.json")
+    st.session_state.simulation = Simulation(grid)
 
-def main():
-    grid: Grid = st.session_state.grid
-    st.title("Miney - Grid Editor")
-    render_grid(grid)
+
+def main() -> None:
+    sim: Simulation = st.session_state.simulation
+    st.title("Miney - Truck Simulator")
+
+    col1, col2, col3 = st.columns(3)
+    if col1.button("Start" if not sim.running else "Stop"):
+        if sim.running:
+            sim.stop()
+        else:
+            sim.start()
+    if col2.button("Reset"):
+        sim.reset()
+    if col3.button("Add Truck"):
+        sim.add_truck()
+
+    if sim.running:
+        sim.step()
+        time.sleep(0.1)
+        st.experimental_rerun()
+
+    render_simulation(sim)
+
+    for truck in sim.trucks:
+        st.write(f"Truck {truck.id}: {truck.state} at {truck.position}")
 
 
 if __name__ == "__main__":

--- a/miney/__init__.py
+++ b/miney/__init__.py
@@ -5,6 +5,7 @@ from .map_loader import load_grid
 from .truck import Truck, TruckState
 from .simulation import Simulation
 from .pathfinder import compute_loop_route
+from .ui import render_simulation, simulation_to_rgb_array, render_grid, TRUCK_COLOR
 
 __all__ = [
     "Grid",
@@ -14,4 +15,8 @@ __all__ = [
     "TruckState",
     "Simulation",
     "compute_loop_route",
+    "render_simulation",
+    "simulation_to_rgb_array",
+    "render_grid",
+    "TRUCK_COLOR",
 ]

--- a/miney/__init__.py
+++ b/miney/__init__.py
@@ -1,0 +1,17 @@
+"""Miney simulation package."""
+
+from .grid import Grid, CellType
+from .map_loader import load_grid
+from .truck import Truck, TruckState
+from .simulation import Simulation
+from .pathfinder import compute_loop_route
+
+__all__ = [
+    "Grid",
+    "CellType",
+    "load_grid",
+    "Truck",
+    "TruckState",
+    "Simulation",
+    "compute_loop_route",
+]

--- a/miney/pathfinder.py
+++ b/miney/pathfinder.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Dict, List, Tuple
+
+from .grid import Grid, CellType
+
+
+def find_first_cell(grid: Grid, cell_type: CellType) -> Tuple[int, int]:
+    """Return coordinates of the first cell of the given type."""
+    for y in range(grid.HEIGHT):
+        for x in range(grid.WIDTH):
+            if grid.get_cell(x, y).type == cell_type:
+                return x, y
+    raise ValueError(f"Cell type {cell_type} not found")
+
+
+def bfs_path(grid: Grid, start: Tuple[int, int], goal: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """Simple BFS to find a path restricted to road/load/dump cells."""
+    allowed = {CellType.ROAD, CellType.LOAD, CellType.DUMP}
+    queue: deque[Tuple[int, int]] = deque([start])
+    came_from: Dict[Tuple[int, int], Tuple[int, int] | None] = {start: None}
+    while queue:
+        x, y = queue.popleft()
+        if (x, y) == goal:
+            break
+        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            nx, ny = x + dx, y + dy
+            if not grid.in_bounds(nx, ny):
+                continue
+            cell = grid.get_cell(nx, ny)
+            if cell.type in allowed and (nx, ny) not in came_from:
+                came_from[(nx, ny)] = (x, y)
+                queue.append((nx, ny))
+    else:
+        raise ValueError("No path found between points")
+
+    path: List[Tuple[int, int]] = []
+    current: Tuple[int, int] | None = goal
+    while current is not None:
+        path.append(current)
+        current = came_from[current]
+    path.reverse()
+    return path
+
+
+def compute_loop_route(grid: Grid) -> Tuple[List[Tuple[int, int]], int]:
+    """Compute a route from load -> dump -> load using BFS.
+
+    Returns the full route and the index of the dump cell within that route.
+    """
+    start = find_first_cell(grid, CellType.LOAD)
+    dump = find_first_cell(grid, CellType.DUMP)
+    to_dump = bfs_path(grid, start, dump)
+    route = to_dump + to_dump[-2::-1]
+    dump_index = len(to_dump) - 1
+    return route, dump_index

--- a/miney/simulation.py
+++ b/miney/simulation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List
+
+from .grid import Grid
+from .pathfinder import compute_loop_route
+from .truck import Truck
+
+
+class Simulation:
+    """Manages trucks moving on a grid."""
+
+    def __init__(self, grid: Grid, load_delay: int = 3, dump_delay: int = 3) -> None:
+        self.grid = grid
+        self.load_delay = load_delay
+        self.dump_delay = dump_delay
+        self.trucks: List[Truck] = []
+        self.route, self.dump_index = compute_loop_route(grid)
+        self._next_id = 1
+        self.running = False
+
+    def start(self) -> None:
+        self.running = True
+
+    def stop(self) -> None:
+        self.running = False
+
+    def reset(self) -> None:
+        self.trucks.clear()
+        self._next_id = 1
+
+    def add_truck(self) -> Truck:
+        truck = Truck(
+            id=self._next_id,
+            route=self.route,
+            dump_index=self.dump_index,
+            load_delay=self.load_delay,
+            dump_delay=self.dump_delay,
+        )
+        self.trucks.append(truck)
+        self._next_id += 1
+        return truck
+
+    def step(self) -> None:
+        if not self.running:
+            return
+        for truck in self.trucks:
+            truck.step()

--- a/miney/truck.py
+++ b/miney/truck.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Tuple
+
+
+class TruckState(str, Enum):
+    """Possible states for a truck."""
+
+    IDLE = "idle"
+    LOADING = "loading"
+    HAULING = "hauling"
+    DUMPING = "dumping"
+    RETURNING = "returning"
+
+
+@dataclass
+class Truck:
+    """A haul truck moving along a predefined route."""
+
+    id: int
+    route: List[Tuple[int, int]]
+    dump_index: int
+    load_delay: int = 3
+    dump_delay: int = 3
+    position: Tuple[int, int] = field(init=False)
+    state: TruckState = field(init=False)
+    _route_index: int = field(init=False, default=0)
+    _wait_timer: int = field(init=False, default=0)
+
+    def __post_init__(self) -> None:
+        self.position = self.route[0]
+        self.state = TruckState.LOADING
+        self._route_index = 0
+        self._wait_timer = self.load_delay
+
+    def step(self) -> None:
+        """Advance the truck by one simulation tick."""
+        if self.state == TruckState.LOADING:
+            if self._wait_timer > 0:
+                self._wait_timer -= 1
+                return
+            self.state = TruckState.HAULING
+            self._route_index = 1
+
+        if self.state == TruckState.DUMPING:
+            if self._wait_timer > 0:
+                self._wait_timer -= 1
+                return
+            self.state = TruckState.RETURNING
+            self._route_index += 1
+
+        if self.state in (TruckState.HAULING, TruckState.RETURNING):
+            self.position = self.route[self._route_index]
+            self._route_index += 1
+            if self.state == TruckState.HAULING and self._route_index - 1 == self.dump_index:
+                self.state = TruckState.DUMPING
+                self._wait_timer = self.dump_delay
+            elif self.state == TruckState.RETURNING and self._route_index == len(self.route):
+                self.state = TruckState.LOADING
+                self._wait_timer = self.load_delay
+                self._route_index = 1
+                self.position = self.route[0]

--- a/miney/ui.py
+++ b/miney/ui.py
@@ -16,6 +16,8 @@ CELL_COLORS = {
     CellType.OBSTACLE: "#000000",
 }
 
+TRUCK_COLOR = "#FFFF00"
+
 
 def grid_to_color_matrix(grid: Grid) -> List[List[str]]:
     """Return a color representation of the grid."""
@@ -48,4 +50,23 @@ def grid_to_rgb_array(grid: Grid, cell_size: int = 10) -> np.ndarray:
 def render_grid(grid: Grid) -> None:
     """Render the grid using Streamlit."""
     arr = grid_to_rgb_array(grid, cell_size=10)
+    st.image(arr, use_container_width=True)
+
+
+def simulation_to_rgb_array(sim, cell_size: int = 10) -> np.ndarray:
+    """Return an RGB array representing the grid with trucks overlaid."""
+    arr = grid_to_rgb_array(sim.grid, cell_size=1)
+    truck_rgb = np.array(hex_to_rgb(TRUCK_COLOR), dtype=np.uint8)
+    for truck in sim.trucks:
+        x, y = truck.position
+        if 0 <= x < sim.grid.WIDTH and 0 <= y < sim.grid.HEIGHT:
+            arr[y, x] = truck_rgb
+    if cell_size > 1:
+        arr = np.kron(arr, np.ones((cell_size, cell_size, 1), dtype=np.uint8))
+    return arr
+
+
+def render_simulation(sim) -> None:
+    """Render the simulation with trucks."""
+    arr = simulation_to_rgb_array(sim, cell_size=10)
     st.image(arr, use_container_width=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest>=7.0
 numpy>=1.21
 networkx>=2.6
 pyyaml>=6.0
+pygame

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,25 @@
+from miney.map_loader import load_grid
+from miney.simulation import Simulation
+from miney.truck import TruckState
+
+
+def test_add_truck_ids_unique():
+    grid = load_grid('maps/simple_map.json')
+    sim = Simulation(grid, load_delay=1, dump_delay=1)
+    t1 = sim.add_truck()
+    t2 = sim.add_truck()
+    assert t1.id == 1
+    assert t2.id == 2
+    assert t1.position == sim.route[0]
+
+
+def test_truck_complete_cycle():
+    grid = load_grid('maps/simple_map.json')
+    sim = Simulation(grid, load_delay=1, dump_delay=1)
+    truck = sim.add_truck()
+    sim.start()
+    steps = len(sim.route)
+    for _ in range(steps):
+        sim.step()
+    assert truck.position == sim.route[0]
+    assert truck.state == TruckState.LOADING

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,13 @@
+import numpy as np
+from miney.map_loader import load_grid
+from miney.simulation import Simulation
+from miney.ui import simulation_to_rgb_array, TRUCK_COLOR, hex_to_rgb
+
+
+def test_simulation_array_overlays_truck():
+    grid = load_grid('maps/simple_map.json')
+    sim = Simulation(grid, load_delay=1, dump_delay=1)
+    truck = sim.add_truck()
+    arr = simulation_to_rgb_array(sim, cell_size=1)
+    x, y = truck.position
+    assert tuple(arr[y, x]) == hex_to_rgb(TRUCK_COLOR)


### PR DESCRIPTION
## Summary
- add new `Truck` dataclass and `TruckState` enum
- implement `Simulation` manager that can spawn trucks and step the simulation
- create `pathfinder` module with a simple BFS-based route from load to dump and back
- document the simulation module in the README
- add tests covering truck lifecycle and simulation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6cc5871c832c87594382fb8d34cd